### PR TITLE
Save both source files and headers

### DIFF
--- a/src/librepo_fs.js
+++ b/src/librepo_fs.js
@@ -138,7 +138,8 @@ export class FileSystemLibraryRepository extends AbstractLibraryRepository {
 	}
 
 	includeLibraryFile(libraryFile) {
-		return libraryFile.kind === 'source';
+		return libraryFile.kind === 'source' ||
+				libraryFile.kind === 'header';
 	}
 
 	/**


### PR DESCRIPTION
When using library manager I noticed it only downloads source files and omits headers. This should change the behaviour.